### PR TITLE
fix: update SITE_URL and canonical URLs to use www subdomain

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -2,7 +2,7 @@
  * Site configuration constants
  */
 
-export const SITE_URL = "https://articleideagenerator.com";
+export const SITE_URL = "https://www.articleideagenerator.com";
 export const SITE_NAME = "Article Idea Generator";
 
 /**

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -8,7 +8,7 @@ export default function Document() {
       <Head>
         <meta charSet="utf-8" />
         <link rel="icon" href="/favicon.ico" />
-        <link rel="canonical" href="https://articleideagenerator.com" />
+        <link rel="canonical" href="https://www.articleideagenerator.com" />
         <link rel="apple-touch-icon" href="/icon-192.png" />
 
         {/* LLM-friendly content */}


### PR DESCRIPTION
Consolidate SEO value - Google was indexing both www and non-www as separate pages