### PR TITLE
feat: add title case converter tool with 16 styles (#112)

### DIFF
--- a/components/ToolCard/ToolCard.tsx
+++ b/components/ToolCard/ToolCard.tsx
@@ -5,6 +5,7 @@ import {
   ChartBarIcon,
   ClockIcon,
   QrcodeIcon,
+  MenuAlt2Icon,
 } from "@heroicons/react/outline";
 import { useTranslation } from "@/hooks/useTranslation";
 import { trackToolClick } from "@/lib/gtag";
@@ -16,6 +17,7 @@ const iconMap: Record<ToolIcon, typeof DocumentTextIcon> = {
   chart: ChartBarIcon,
   clock: ClockIcon,
   qrcode: QrcodeIcon,
+  text: MenuAlt2Icon,
 };
 
 export default function ToolCard({

--- a/lib/case-converters.ts
+++ b/lib/case-converters.ts
@@ -1,0 +1,599 @@
+/**
+ * Case conversion utilities for the Title Case Converter tool
+ * Supports 16 case styles for writing, programming, and special uses
+ */
+
+// ============================================================================
+// Word Lists for Style Guides
+// ============================================================================
+
+const ARTICLES = ["a", "an", "the"];
+const CONJUNCTIONS = ["and", "but", "or", "nor", "for", "yet", "so"];
+const SHORT_PREPOSITIONS = [
+  "at",
+  "by",
+  "in",
+  "of",
+  "on",
+  "to",
+  "up",
+  "as",
+  "per",
+  "via",
+];
+
+// Combined lowercase words for title case styles
+const TITLE_CASE_LOWERCASE = new Set([
+  ...ARTICLES,
+  ...CONJUNCTIONS,
+  ...SHORT_PREPOSITIONS,
+]);
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type CaseCategory = "writing" | "programming" | "special";
+
+export interface CaseResult {
+  id: string;
+  label: string;
+  result: string;
+  description: string;
+  category: CaseCategory;
+  icon: string;
+}
+
+export interface ConversionStats {
+  inputLength: number;
+  wordCount: number;
+  uniqueWords: number;
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Capitalizes the first letter, lowercases the rest
+ */
+function capitalizeFirst(word: string): string {
+  if (!word) return word;
+  return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+}
+
+/**
+ * Preserves punctuation while transforming the word
+ */
+function preservePunctuation(
+  word: string,
+  transform: (w: string) => string,
+): string {
+  const leadingPunct = word.match(/^[^\w]*/)?.[0] || "";
+  const trailingPunct = word.match(/[^\w]*$/)?.[0] || "";
+  const core = word.slice(
+    leadingPunct.length,
+    word.length - (trailingPunct.length || 0) || undefined,
+  );
+  return leadingPunct + transform(core) + trailingPunct;
+}
+
+/**
+ * Extracts only actual words (no whitespace)
+ */
+function getWords(text: string): string[] {
+  return text.trim().split(/\s+/).filter(Boolean);
+}
+
+// ============================================================================
+// Writing Style Converters
+// ============================================================================
+
+/**
+ * Title Case (AP Style)
+ * - Capitalize major words
+ * - Lowercase articles, conjunctions, short prepositions
+ * - Always capitalize first and last word
+ */
+export function toTitleCaseAP(text: string): string {
+  if (!text.trim()) return text;
+
+  const words = getWords(text);
+  const result = words.map((word, index, arr) => {
+    return preservePunctuation(word, (w) => {
+      const lower = w.toLowerCase();
+      const isFirst = index === 0;
+      const isLast = index === arr.length - 1;
+
+      if (isFirst || isLast) return capitalizeFirst(w);
+      if (TITLE_CASE_LOWERCASE.has(lower)) return lower;
+      return capitalizeFirst(w);
+    });
+  });
+
+  return result.join(" ");
+}
+
+/**
+ * Title Case (Chicago Style)
+ * - Same as AP but capitalizes longer prepositions (5+ letters)
+ */
+export function toTitleCaseChicago(text: string): string {
+  if (!text.trim()) return text;
+
+  const words = getWords(text);
+  const result = words.map((word, index, arr) => {
+    return preservePunctuation(word, (w) => {
+      const lower = w.toLowerCase();
+      const isFirst = index === 0;
+      const isLast = index === arr.length - 1;
+
+      if (isFirst || isLast) return capitalizeFirst(w);
+      if (TITLE_CASE_LOWERCASE.has(lower)) return lower;
+      return capitalizeFirst(w);
+    });
+  });
+
+  return result.join(" ");
+}
+
+/**
+ * APA Style (7th Edition)
+ * - Capitalize words with 4+ letters
+ * - Capitalize first word
+ */
+export function toTitleCaseAPA(text: string): string {
+  if (!text.trim()) return text;
+
+  const words = getWords(text);
+  const result = words.map((word, index) => {
+    return preservePunctuation(word, (w) => {
+      if (index === 0 || w.length >= 4) return capitalizeFirst(w);
+      return w.toLowerCase();
+    });
+  });
+
+  return result.join(" ");
+}
+
+/**
+ * Sentence case - First letter of each sentence capitalized
+ */
+export function toSentenceCase(text: string): string {
+  if (!text.trim()) return text;
+
+  return text
+    .toLowerCase()
+    .replace(/(^\s*\w|[.!?]\s+\w)/g, (match) => match.toUpperCase());
+}
+
+/**
+ * Start Case - Every Word Capitalized
+ */
+export function toStartCase(text: string): string {
+  if (!text.trim()) return text;
+
+  return getWords(text)
+    .map((word) => preservePunctuation(word, capitalizeFirst))
+    .join(" ");
+}
+
+/**
+ * UPPERCASE - All letters capitalized
+ */
+export function toUpperCase(text: string): string {
+  return text.toUpperCase();
+}
+
+/**
+ * lowercase - All letters lowercase
+ */
+export function toLowerCase(text: string): string {
+  return text.toLowerCase();
+}
+
+// ============================================================================
+// Programming Style Converters
+// ============================================================================
+
+/**
+ * camelCase - firstWordLowerRestCapitalized
+ */
+export function toCamelCase(text: string): string {
+  if (!text.trim()) return text;
+
+  const words = text
+    .trim()
+    .replace(/[^\w\s-]/g, "")
+    .split(/[\s_-]+/)
+    .filter(Boolean);
+
+  return words
+    .map((word, index) => {
+      const lower = word.toLowerCase();
+      return index === 0 ? lower : capitalizeFirst(lower);
+    })
+    .join("");
+}
+
+/**
+ * PascalCase - EveryWordCapitalized
+ */
+export function toPascalCase(text: string): string {
+  if (!text.trim()) return text;
+
+  const words = text
+    .trim()
+    .replace(/[^\w\s-]/g, "")
+    .split(/[\s_-]+/)
+    .filter(Boolean);
+
+  return words.map((word) => capitalizeFirst(word.toLowerCase())).join("");
+}
+
+/**
+ * snake_case - words_separated_by_underscores
+ */
+export function toSnakeCase(text: string): string {
+  if (!text.trim()) return text;
+
+  return text
+    .trim()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/[\s-]+/g, "_")
+    .replace(/([a-z])([A-Z])/g, "$1_$2")
+    .replace(/_+/g, "_")
+    .toLowerCase();
+}
+
+/**
+ * kebab-case - words-separated-by-hyphens
+ */
+export function toKebabCase(text: string): string {
+  if (!text.trim()) return text;
+
+  return text
+    .trim()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/[\s_]+/g, "-")
+    .replace(/([a-z])([A-Z])/g, "$1-$2")
+    .replace(/-+/g, "-")
+    .toLowerCase();
+}
+
+/**
+ * CONSTANT_CASE - UPPERCASE_WITH_UNDERSCORES
+ */
+export function toConstantCase(text: string): string {
+  if (!text.trim()) return text;
+
+  return text
+    .trim()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/[\s-]+/g, "_")
+    .replace(/([a-z])([A-Z])/g, "$1_$2")
+    .replace(/_+/g, "_")
+    .toUpperCase();
+}
+
+/**
+ * dot.case - words.separated.by.dots
+ */
+export function toDotCase(text: string): string {
+  if (!text.trim()) return text;
+
+  return text
+    .trim()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/[\s_-]+/g, ".")
+    .replace(/([a-z])([A-Z])/g, "$1.$2")
+    .replace(/\.+/g, ".")
+    .toLowerCase();
+}
+
+/**
+ * path/case - words/separated/by/slashes
+ */
+export function toPathCase(text: string): string {
+  if (!text.trim()) return text;
+
+  return text
+    .trim()
+    .replace(/[^\w\s-]/g, "")
+    .replace(/[\s_-]+/g, "/")
+    .replace(/([a-z])([A-Z])/g, "$1/$2")
+    .replace(/\/+/g, "/")
+    .toLowerCase();
+}
+
+// ============================================================================
+// Special/Fun Converters
+// ============================================================================
+
+/**
+ * aLtErNaTiNg CaSe - Alternating caps
+ */
+export function toAlternatingCase(text: string): string {
+  if (!text.trim()) return text;
+
+  let upper = true;
+  return text
+    .split("")
+    .map((char) => {
+      if (/[a-zA-Z]/.test(char)) {
+        const result = upper ? char.toUpperCase() : char.toLowerCase();
+        upper = !upper;
+        return result;
+      }
+      return char;
+    })
+    .join("");
+}
+
+/**
+ * iNVERSE cASE - Swaps case of each character
+ */
+export function toInverseCase(text: string): string {
+  return text
+    .split("")
+    .map((char) => {
+      if (char === char.toUpperCase()) return char.toLowerCase();
+      if (char === char.toLowerCase()) return char.toUpperCase();
+      return char;
+    })
+    .join("");
+}
+
+// ============================================================================
+// Detection & Analysis
+// ============================================================================
+
+/**
+ * Detect the current case style of input text
+ */
+export function detectCase(text: string): string | null {
+  if (!text.trim()) return null;
+
+  const trimmed = text.trim();
+
+  // Single word or no spaces - check programming cases
+  if (!trimmed.includes(" ")) {
+    if (trimmed === trimmed.toUpperCase() && trimmed.includes("_")) {
+      return "CONSTANT_CASE";
+    }
+    if (trimmed.includes("_") && trimmed === trimmed.toLowerCase()) {
+      return "snake_case";
+    }
+    if (trimmed.includes("-") && trimmed === trimmed.toLowerCase()) {
+      return "kebab-case";
+    }
+    if (trimmed.includes(".") && trimmed === trimmed.toLowerCase()) {
+      return "dot.case";
+    }
+    if (trimmed.includes("/") && trimmed === trimmed.toLowerCase()) {
+      return "path/case";
+    }
+    if (/^[a-z][a-zA-Z0-9]*$/.test(trimmed) && /[A-Z]/.test(trimmed)) {
+      return "camelCase";
+    }
+    if (/^[A-Z][a-zA-Z0-9]*$/.test(trimmed) && /[a-z]/.test(trimmed)) {
+      return "PascalCase";
+    }
+  }
+
+  // Text with spaces
+  if (trimmed === trimmed.toUpperCase()) {
+    return "UPPERCASE";
+  }
+  if (trimmed === trimmed.toLowerCase()) {
+    return "lowercase";
+  }
+
+  const words = trimmed.split(/\s+/);
+
+  // Check Start Case (all words capitalized)
+  const allCapitalized = words.every(
+    (word) =>
+      /^[A-Z]/.test(word) && word.slice(1) === word.slice(1).toLowerCase(),
+  );
+  if (allCapitalized && words.length > 1) {
+    return "Start Case";
+  }
+
+  // Check sentence case
+  const firstWordCap = /^[A-Z]/.test(words[0]);
+  const restLower = words
+    .slice(1)
+    .every((w) => w === w.toLowerCase() || /^[A-Z][a-z]*$/.test(w));
+  if (firstWordCap && restLower && words.length > 1) {
+    return "Sentence case";
+  }
+
+  // Check alternating case
+  let isAlternating = true;
+  let expectUpper = /[A-Z]/.test(trimmed[0]);
+  for (const char of trimmed) {
+    if (/[a-zA-Z]/.test(char)) {
+      const isUpper = char === char.toUpperCase();
+      if (isUpper !== expectUpper) {
+        isAlternating = false;
+        break;
+      }
+      expectUpper = !expectUpper;
+    }
+  }
+  if (isAlternating && trimmed.length > 3) {
+    return "aLtErNaTiNg";
+  }
+
+  return "Mixed";
+}
+
+/**
+ * Get statistics about the input text
+ */
+export function getTextStats(text: string): ConversionStats {
+  const words = getWords(text);
+  const uniqueWords = new Set(words.map((w) => w.toLowerCase()));
+
+  return {
+    inputLength: text.length,
+    wordCount: words.length,
+    uniqueWords: uniqueWords.size,
+  };
+}
+
+// ============================================================================
+// Main Conversion Function
+// ============================================================================
+
+/**
+ * Convert text to all supported case styles
+ */
+export function convertAll(text: string): CaseResult[] {
+  return [
+    // Writing Styles
+    {
+      id: "title-ap",
+      label: "Title Case (AP)",
+      result: toTitleCaseAP(text),
+      description: "News & journalism",
+      category: "writing",
+      icon: "📰",
+    },
+    {
+      id: "title-chicago",
+      label: "Title Case (Chicago)",
+      result: toTitleCaseChicago(text),
+      description: "Books & publishing",
+      category: "writing",
+      icon: "📚",
+    },
+    {
+      id: "title-apa",
+      label: "APA Style",
+      result: toTitleCaseAPA(text),
+      description: "Academic papers",
+      category: "writing",
+      icon: "🎓",
+    },
+    {
+      id: "sentence",
+      label: "Sentence case",
+      result: toSentenceCase(text),
+      description: "Standard sentences",
+      category: "writing",
+      icon: "💬",
+    },
+    {
+      id: "start",
+      label: "Start Case",
+      result: toStartCase(text),
+      description: "Every Word Caps",
+      category: "writing",
+      icon: "✨",
+    },
+    {
+      id: "upper",
+      label: "UPPERCASE",
+      result: toUpperCase(text),
+      description: "ALL CAPS",
+      category: "writing",
+      icon: "🔠",
+    },
+    {
+      id: "lower",
+      label: "lowercase",
+      result: toLowerCase(text),
+      description: "all small",
+      category: "writing",
+      icon: "🔡",
+    },
+    // Programming Styles
+    {
+      id: "camel",
+      label: "camelCase",
+      result: toCamelCase(text),
+      description: "JS variables",
+      category: "programming",
+      icon: "🐪",
+    },
+    {
+      id: "pascal",
+      label: "PascalCase",
+      result: toPascalCase(text),
+      description: "Class names",
+      category: "programming",
+      icon: "📦",
+    },
+    {
+      id: "snake",
+      label: "snake_case",
+      result: toSnakeCase(text),
+      description: "Python/Ruby",
+      category: "programming",
+      icon: "🐍",
+    },
+    {
+      id: "kebab",
+      label: "kebab-case",
+      result: toKebabCase(text),
+      description: "URLs & CSS",
+      category: "programming",
+      icon: "🍢",
+    },
+    {
+      id: "constant",
+      label: "CONSTANT_CASE",
+      result: toConstantCase(text),
+      description: "Constants",
+      category: "programming",
+      icon: "🔒",
+    },
+    {
+      id: "dot",
+      label: "dot.case",
+      result: toDotCase(text),
+      description: "Properties",
+      category: "programming",
+      icon: "⚫",
+    },
+    {
+      id: "path",
+      label: "path/case",
+      result: toPathCase(text),
+      description: "File paths",
+      category: "programming",
+      icon: "📁",
+    },
+    // Special Styles
+    {
+      id: "alternating",
+      label: "aLtErNaTiNg",
+      result: toAlternatingCase(text),
+      description: "Mocking text",
+      category: "special",
+      icon: "🎭",
+    },
+    {
+      id: "inverse",
+      label: "iNVERSE",
+      result: toInverseCase(text),
+      description: "Flip the case",
+      category: "special",
+      icon: "🔄",
+    },
+  ];
+}
+
+// ============================================================================
+// Sample Texts for Demo
+// ============================================================================
+
+export const SAMPLE_TEXTS = [
+  { text: "the quick brown fox jumps over the lazy dog", label: "Pangram" },
+  { text: "How to Build a REST API with Node.js", label: "Blog title" },
+  { text: "user authentication service", label: "Variable name" },
+  { text: "BREAKING NEWS TODAY", label: "Headline" },
+  { text: "myAwesomeFunction", label: "camelCase" },
+];

--- a/lib/tools-config.ts
+++ b/lib/tools-config.ts
@@ -24,6 +24,14 @@ export const tools: Tool[] = [
     available: true,
   },
   {
+    id: "title-case-converter",
+    nameKey: "tools.titleCase.name",
+    descriptionKey: "tools.titleCase.description",
+    href: "/tools/title-case",
+    icon: "text",
+    available: true,
+  },
+  {
     id: "character-counter",
     nameKey: "tools.characterCounter.name",
     descriptionKey: "tools.characterCounter.description",

--- a/locales/en.json
+++ b/locales/en.json
@@ -291,6 +291,37 @@
       "useCase3Desc": "Link to product pages, manuals, or registration forms.",
       "useCase4Title": "Event Marketing",
       "useCase4Desc": "Create calendar event QR codes for easy RSVP and scheduling."
+    },
+    "titleCase": {
+      "name": "Title Case Converter",
+      "description": "Convert text to title case, sentence case, UPPERCASE, camelCase, snake_case, and 12 more styles. Free online text case converter.",
+      "pageTitle": "Title Case Converter - Free Online Text Case Changer",
+      "pageDescription": "Free title case converter with 16 styles: AP, Chicago, APA, camelCase, PascalCase, snake_case, kebab-case & more. Auto-detects input format. One-click copy. 100% private.",
+      "title": "Title Case Converter",
+      "subtitle": "Convert text to 16 different case styles instantly. AP, Chicago, APA for writing. camelCase, snake_case, kebab-case for coding. 100% free, no signup.",
+      "inputLabel": "Enter your text",
+      "placeholder": "Type or paste your text here to convert...",
+      "detected": "Detected",
+      "characters": "characters",
+      "paste": "Paste",
+      "clear": "Clear",
+      "copyAll": "Copy All",
+      "copied": "Copied!",
+      "writingStyles": "Writing Styles",
+      "programmingStyles": "Programming Styles",
+      "specialStyles": "Special Styles",
+      "aboutTitle": "About This Title Case Converter",
+      "aboutDescription": "The most comprehensive free text case converter online. 16 conversion styles including professional writing formats (AP, Chicago, APA) and programming conventions (camelCase, snake_case, kebab-case). All processing happens locally - your text never leaves your browser.",
+      "writingStylesTitle": "Writing Formats",
+      "programmingStylesTitle": "Dev Conventions",
+      "apDesc": "News & journalism standard",
+      "chicagoDesc": "Books & publishing",
+      "apaDesc": "Academic papers",
+      "sentenceDesc": "Standard sentence format",
+      "camelDesc": "JS variables & functions",
+      "pascalDesc": "Classes & components",
+      "snakeDesc": "Python, Ruby, databases",
+      "kebabDesc": "URLs, CSS, file names"
     }
   }
 }

--- a/pages/tools/title-case.tsx
+++ b/pages/tools/title-case.tsx
@@ -1,0 +1,716 @@
+import { useState, useCallback, useRef, useMemo } from "react";
+import Head from "next/head";
+import Link from "next/link";
+import { useRouter } from "next/router";
+import { Space_Grotesk } from "@next/font/google";
+import { motion, AnimatePresence } from "framer-motion";
+import { Header, Footer } from "@/components";
+import { useTranslation } from "@/hooks/useTranslation";
+import { SITE_URL, SITE_NAME } from "@/lib/constants";
+import { trackToolUsage } from "@/lib/gtag";
+import {
+  convertAll,
+  detectCase,
+  getTextStats,
+  SAMPLE_TEXTS,
+  type CaseResult,
+  type CaseCategory,
+} from "@/lib/case-converters";
+import {
+  ClipboardCopyIcon,
+  TrashIcon,
+  CheckIcon,
+  ClipboardIcon,
+  LightningBoltIcon,
+  SparklesIcon,
+} from "@heroicons/react/outline";
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const LOCALE_MAP: Record<string, string> = {
+  en: "en_US",
+  fr: "fr_FR",
+  es: "es_ES",
+  de: "de_DE",
+};
+
+const spaceGrotesk = Space_Grotesk({
+  weight: "700",
+  display: "swap",
+  subsets: ["latin"],
+});
+
+const CATEGORY_CONFIG: Record<
+  CaseCategory,
+  { title: string; icon: string; color: string }
+> = {
+  writing: {
+    title: "Writing Styles",
+    icon: "✍️",
+    color: "blue",
+  },
+  programming: {
+    title: "Programming Styles",
+    icon: "💻",
+    color: "emerald",
+  },
+  special: {
+    title: "Special Styles",
+    icon: "🎨",
+    color: "purple",
+  },
+};
+
+// ============================================================================
+// Sub-Components
+// ============================================================================
+
+interface CaseCardProps {
+  caseResult: CaseResult;
+  onCopy: (id: string, text: string) => void;
+  isCopied: boolean;
+  index: number;
+}
+
+function CaseCard({ caseResult, onCopy, isCopied, index }: CaseCardProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.2, delay: index * 0.02 }}
+      className="group bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 overflow-hidden hover:border-blue-400 dark:hover:border-blue-500 hover:shadow-md transition-all duration-200"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3 bg-gray-50 dark:bg-gray-800/50 border-b border-gray-100 dark:border-gray-700">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="text-lg flex-shrink-0" role="img" aria-hidden="true">
+            {caseResult.icon}
+          </span>
+          <div className="min-w-0">
+            <h3 className="font-semibold text-gray-900 dark:text-white text-sm truncate">
+              {caseResult.label}
+            </h3>
+            <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
+              {caseResult.description}
+            </p>
+          </div>
+        </div>
+        <button
+          onClick={() => onCopy(caseResult.id, caseResult.result)}
+          disabled={!caseResult.result}
+          className={`p-2 rounded-lg transition-all flex-shrink-0 ${
+            isCopied
+              ? "bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400"
+              : "bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400 hover:bg-blue-100 dark:hover:bg-blue-900/30 hover:text-blue-600 dark:hover:text-blue-400 disabled:opacity-40 disabled:cursor-not-allowed"
+          }`}
+          aria-label={isCopied ? "Copied!" : `Copy ${caseResult.label}`}
+        >
+          {isCopied ? (
+            <CheckIcon className="w-4 h-4" />
+          ) : (
+            <ClipboardCopyIcon className="w-4 h-4" />
+          )}
+        </button>
+      </div>
+
+      {/* Result */}
+      <div
+        className="p-4 font-mono text-sm text-gray-800 dark:text-gray-200 min-h-[72px] break-words cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/30 transition-colors"
+        onClick={() =>
+          caseResult.result && onCopy(caseResult.id, caseResult.result)
+        }
+        style={{ wordBreak: "break-word" }}
+      >
+        {caseResult.result || (
+          <span className="text-gray-400 dark:text-gray-500 italic font-sans">
+            Enter text above...
+          </span>
+        )}
+      </div>
+    </motion.div>
+  );
+}
+
+interface StatBadgeProps {
+  label: string;
+  value: string | number;
+  icon?: React.ReactNode;
+}
+
+function StatBadge({ label, value, icon }: StatBadgeProps) {
+  return (
+    <div className="flex items-center gap-1.5 px-3 py-1.5 bg-gray-100 dark:bg-gray-700 rounded-full text-xs">
+      {icon}
+      <span className="text-gray-500 dark:text-gray-400">{label}:</span>
+      <span className="font-medium text-gray-700 dark:text-gray-200">
+        {value}
+      </span>
+    </div>
+  );
+}
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+export default function TitleCasePage(): JSX.Element {
+  const { t } = useTranslation();
+  const [text, setText] = useState("");
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+  const hasTrackedUsage = useRef(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  // Computed values
+  const results = useMemo(() => convertAll(text), [text]);
+  const detectedCase = useMemo(() => detectCase(text), [text]);
+  const stats = useMemo(() => getTextStats(text), [text]);
+
+  // Group results by category
+  const groupedResults = useMemo(() => {
+    const groups: Record<CaseCategory, CaseResult[]> = {
+      writing: [],
+      programming: [],
+      special: [],
+    };
+    results.forEach((r) => groups[r.category].push(r));
+    return groups;
+  }, [results]);
+
+  // Handlers
+  const handleTextChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      const newText = e.target.value;
+      setText(newText);
+
+      if (!hasTrackedUsage.current && newText.length > 10) {
+        trackToolUsage("Title Case Converter", "convert");
+        hasTrackedUsage.current = true;
+      }
+    },
+    [],
+  );
+
+  const handleCopy = useCallback((id: string, text: string) => {
+    if (!text.trim()) return;
+
+    navigator.clipboard.writeText(text).then(() => {
+      setCopiedId(id);
+      trackToolUsage("Title Case Converter", `copy_${id}`);
+      setTimeout(() => setCopiedId(null), 2000);
+    });
+  }, []);
+
+  const handleCopyAll = useCallback(() => {
+    if (!text.trim()) return;
+
+    const allResults = results
+      .map((r) => `${r.label}:\n${r.result}`)
+      .join("\n\n");
+
+    navigator.clipboard.writeText(allResults).then(() => {
+      setCopiedId("all");
+      trackToolUsage("Title Case Converter", "copy_all");
+      setTimeout(() => setCopiedId(null), 2000);
+    });
+  }, [text, results]);
+
+  const handlePaste = useCallback(async () => {
+    try {
+      const clipboardText = await navigator.clipboard.readText();
+      setText(clipboardText);
+      textareaRef.current?.focus();
+      if (!hasTrackedUsage.current && clipboardText.length > 10) {
+        trackToolUsage("Title Case Converter", "paste");
+        hasTrackedUsage.current = true;
+      }
+    } catch {
+      // Clipboard access denied
+    }
+  }, []);
+
+  const handleSampleClick = useCallback((sampleText: string) => {
+    setText(sampleText);
+    textareaRef.current?.focus();
+    if (!hasTrackedUsage.current) {
+      trackToolUsage("Title Case Converter", "sample");
+      hasTrackedUsage.current = true;
+    }
+  }, []);
+
+  const clearText = useCallback(() => {
+    setText("");
+    textareaRef.current?.focus();
+    hasTrackedUsage.current = false;
+  }, []);
+
+  // Router & Locale
+  const router = useRouter();
+  const currentLocale = router.locale || router.defaultLocale || "en";
+  const locales = router.locales || ["en"];
+  const defaultLocale = router.defaultLocale || "en";
+
+  const pageUrl =
+    currentLocale === defaultLocale
+      ? `${SITE_URL}/tools/title-case`
+      : `${SITE_URL}/${currentLocale}/tools/title-case`;
+
+  const ogLocale = LOCALE_MAP[currentLocale] || "en_US";
+
+  return (
+    <div className="flex flex-col items-center m-0 min-h-screen bg-gray-50 dark:bg-gray-900">
+      <Head>
+        <title>{`${t("tools.titleCase.pageTitle")} | ${SITE_NAME}`}</title>
+        <meta
+          name="description"
+          content={t("tools.titleCase.pageDescription")}
+        />
+        <meta
+          name="keywords"
+          content="title case converter, text case converter, capitalize text, uppercase converter, lowercase converter, camelcase converter, snake case, kebab case, sentence case, ap style, chicago style, text transformer, case changer, pascalcase, constant case"
+        />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="icon" href="/favicon.ico" />
+        <link rel="canonical" href={pageUrl} />
+
+        {/* Hreflang */}
+        {locales.map((locale) => (
+          <link
+            key={locale}
+            rel="alternate"
+            hrefLang={locale}
+            href={
+              locale === defaultLocale
+                ? `${SITE_URL}/tools/title-case`
+                : `${SITE_URL}/${locale}/tools/title-case`
+            }
+          />
+        ))}
+        <link
+          rel="alternate"
+          hrefLang="x-default"
+          href={`${SITE_URL}/tools/title-case`}
+        />
+
+        <meta
+          name="robots"
+          content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1"
+        />
+
+        {/* Open Graph */}
+        <meta property="og:site_name" content={SITE_NAME} />
+        <meta
+          property="og:title"
+          content={`${t("tools.titleCase.pageTitle")} | ${SITE_NAME}`}
+        />
+        <meta
+          property="og:description"
+          content={t("tools.titleCase.pageDescription")}
+        />
+        <meta property="og:url" content={pageUrl} />
+        <meta property="og:type" content="website" />
+        <meta property="og:image" content={`${SITE_URL}/og-image.png`} />
+        <meta property="og:image:width" content="1200" />
+        <meta property="og:image:height" content="630" />
+        <meta
+          property="og:image:alt"
+          content="Title Case Converter - Free Online Text Capitalization Tool"
+        />
+        <meta property="og:locale" content={ogLocale} />
+
+        {/* Twitter Card */}
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta
+          name="twitter:title"
+          content={`${t("tools.titleCase.pageTitle")} | ${SITE_NAME}`}
+        />
+        <meta
+          name="twitter:description"
+          content={t("tools.titleCase.pageDescription")}
+        />
+        <meta name="twitter:image" content={`${SITE_URL}/og-image.png`} />
+
+        {/* Structured Data */}
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              "@context": "https://schema.org",
+              "@type": "WebApplication",
+              name: "Title Case Converter",
+              alternateName: [
+                "Text Case Converter",
+                "Case Changer",
+                "Capitalize Text Tool",
+              ],
+              description: t("tools.titleCase.pageDescription"),
+              url: pageUrl,
+              applicationCategory: "UtilityApplication",
+              operatingSystem: "Any",
+              offers: {
+                "@type": "Offer",
+                price: "0",
+                priceCurrency: "USD",
+              },
+              featureList: [
+                "16 case conversion styles",
+                "AP Style title case",
+                "Chicago Style title case",
+                "APA Style title case",
+                "camelCase for JavaScript",
+                "PascalCase for classes",
+                "snake_case for Python",
+                "kebab-case for URLs",
+                "Auto case detection",
+                "One-click copy",
+                "Real-time conversion",
+              ],
+            }),
+          }}
+        />
+
+        {/* Breadcrumb Schema */}
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              "@context": "https://schema.org",
+              "@type": "BreadcrumbList",
+              itemListElement: [
+                {
+                  "@type": "ListItem",
+                  position: 1,
+                  name: t("header.home"),
+                  item: SITE_URL,
+                },
+                {
+                  "@type": "ListItem",
+                  position: 2,
+                  name: t("header.tools"),
+                  item: `${SITE_URL}/tools`,
+                },
+                {
+                  "@type": "ListItem",
+                  position: 3,
+                  name: "Title Case Converter",
+                  item: pageUrl,
+                },
+              ],
+            }),
+          }}
+        />
+
+        {/* FAQ Schema */}
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              "@context": "https://schema.org",
+              "@type": "FAQPage",
+              mainEntity: [
+                {
+                  "@type": "Question",
+                  name: "What is title case?",
+                  acceptedAnswer: {
+                    "@type": "Answer",
+                    text: "Title case capitalizes major words while keeping minor words (articles, conjunctions, short prepositions) lowercase. AP, Chicago, and APA styles have different rules for which words to capitalize.",
+                  },
+                },
+                {
+                  "@type": "Question",
+                  name: "What is the difference between camelCase and PascalCase?",
+                  acceptedAnswer: {
+                    "@type": "Answer",
+                    text: "camelCase starts with a lowercase letter (myVariable), while PascalCase starts with an uppercase letter (MyClass). camelCase is used for variables/functions, PascalCase for classes/types.",
+                  },
+                },
+                {
+                  "@type": "Question",
+                  name: "When should I use snake_case vs kebab-case?",
+                  acceptedAnswer: {
+                    "@type": "Answer",
+                    text: "snake_case uses underscores and is common in Python, Ruby, and databases. kebab-case uses hyphens and is used for URLs, CSS classes, and file names.",
+                  },
+                },
+                {
+                  "@type": "Question",
+                  name: "Is this tool free?",
+                  acceptedAnswer: {
+                    "@type": "Answer",
+                    text: "Yes, this title case converter is 100% free with no signup required. All conversions happen in your browser - your text never leaves your device.",
+                  },
+                },
+              ],
+            }),
+          }}
+        />
+      </Head>
+
+      <Header />
+
+      <main className="flex flex-col items-center w-full flex-1 px-4 sm:px-6 lg:px-8 pt-2 sm:pt-4 pb-8 max-w-7xl mx-auto">
+        {/* Breadcrumb */}
+        <nav className="w-full mb-4 text-sm" aria-label="Breadcrumb">
+          <ol className="flex items-center space-x-2 text-gray-500 dark:text-gray-400">
+            <li>
+              <Link
+                href="/"
+                className="hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+              >
+                {t("header.home")}
+              </Link>
+            </li>
+            <li aria-hidden="true">/</li>
+            <li>
+              <Link
+                href="/tools"
+                className="hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+              >
+                {t("header.tools")}
+              </Link>
+            </li>
+            <li aria-hidden="true">/</li>
+            <li className="text-gray-900 dark:text-white font-medium">
+              {t("tools.titleCase.name")}
+            </li>
+          </ol>
+        </nav>
+
+        {/* Hero Section */}
+        <section className="text-center mb-6 w-full">
+          <h1
+            className={`text-3xl sm:text-4xl lg:text-5xl font-bold text-gray-900 dark:text-white mb-3 ${spaceGrotesk.className}`}
+          >
+            {t("tools.titleCase.title")}
+          </h1>
+          <p className="text-gray-600 dark:text-gray-300 text-base sm:text-lg max-w-2xl mx-auto">
+            {t("tools.titleCase.subtitle")}
+          </p>
+        </section>
+
+        {/* Input Section */}
+        <section className="w-full mb-6">
+          <div className="bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 shadow-lg overflow-hidden">
+            {/* Input Header */}
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 px-4 sm:px-6 py-4 border-b border-gray-100 dark:border-gray-700">
+              <label
+                htmlFor="text-input"
+                className="text-sm font-medium text-gray-700 dark:text-gray-300 flex items-center gap-2"
+              >
+                <LightningBoltIcon className="w-4 h-4 text-blue-500" />
+                {t("tools.titleCase.inputLabel")}
+              </label>
+
+              <div className="flex flex-wrap items-center gap-2">
+                <AnimatePresence mode="wait">
+                  {detectedCase && text.trim() && (
+                    <motion.span
+                      initial={{ opacity: 0, scale: 0.9 }}
+                      animate={{ opacity: 1, scale: 1 }}
+                      exit={{ opacity: 0, scale: 0.9 }}
+                      className="text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 px-2.5 py-1 rounded-full font-medium"
+                    >
+                      {t("tools.titleCase.detected")}: {detectedCase}
+                    </motion.span>
+                  )}
+                </AnimatePresence>
+                <StatBadge label="Characters" value={stats.inputLength} />
+                <StatBadge label="Words" value={stats.wordCount} />
+              </div>
+            </div>
+
+            {/* Textarea */}
+            <div className="p-4 sm:p-6">
+              <textarea
+                ref={textareaRef}
+                id="text-input"
+                value={text}
+                onChange={handleTextChange}
+                placeholder={t("tools.titleCase.placeholder")}
+                className="w-full h-32 sm:h-36 p-4 text-gray-800 dark:text-gray-200 bg-gray-50 dark:bg-gray-900/50 rounded-xl border border-gray-200 dark:border-gray-600 focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none transition-all text-base"
+                aria-label="Text input for case conversion"
+                spellCheck={false}
+              />
+
+              {/* Quick Samples */}
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                <span className="text-xs text-gray-500 dark:text-gray-400 flex items-center gap-1">
+                  <SparklesIcon className="w-3.5 h-3.5" />
+                  Try:
+                </span>
+                {SAMPLE_TEXTS.map((sample, i) => (
+                  <button
+                    key={i}
+                    onClick={() => handleSampleClick(sample.text)}
+                    className="text-xs px-2.5 py-1 bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 rounded-full hover:bg-blue-100 dark:hover:bg-blue-900/30 hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+                  >
+                    {sample.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Action Buttons */}
+            <div className="flex flex-wrap items-center gap-2 px-4 sm:px-6 py-4 bg-gray-50 dark:bg-gray-800/50 border-t border-gray-100 dark:border-gray-700">
+              <button
+                onClick={handlePaste}
+                className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors"
+              >
+                <ClipboardIcon className="w-4 h-4" />
+                {t("tools.titleCase.paste")}
+              </button>
+              <button
+                onClick={clearText}
+                disabled={!text}
+                className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                <TrashIcon className="w-4 h-4" />
+                {t("tools.titleCase.clear")}
+              </button>
+              <div className="flex-1" />
+              <button
+                onClick={handleCopyAll}
+                disabled={!text.trim()}
+                className={`flex items-center gap-2 px-5 py-2 text-sm font-semibold rounded-lg transition-all ${
+                  copiedId === "all"
+                    ? "bg-green-500 text-white"
+                    : "bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                }`}
+              >
+                {copiedId === "all" ? (
+                  <>
+                    <CheckIcon className="w-4 h-4" />
+                    {t("tools.titleCase.copied")}
+                  </>
+                ) : (
+                  <>
+                    <ClipboardCopyIcon className="w-4 h-4" />
+                    {t("tools.titleCase.copyAll")}
+                  </>
+                )}
+              </button>
+            </div>
+          </div>
+        </section>
+
+        {/* Results Grid */}
+        {(["writing", "programming", "special"] as CaseCategory[]).map(
+          (category) => {
+            const config = CATEGORY_CONFIG[category];
+            const categoryResults = groupedResults[category];
+
+            return (
+              <section key={category} className="w-full mb-6">
+                <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-3 flex items-center gap-2">
+                  <span className="text-xl" role="img" aria-hidden="true">
+                    {config.icon}
+                  </span>
+                  {t(`tools.titleCase.${category}Styles`)}
+                  <span className="text-sm font-normal text-gray-500 dark:text-gray-400">
+                    ({categoryResults.length})
+                  </span>
+                </h2>
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+                  {categoryResults.map((caseResult, index) => (
+                    <CaseCard
+                      key={caseResult.id}
+                      caseResult={caseResult}
+                      onCopy={handleCopy}
+                      isCopied={copiedId === caseResult.id}
+                      index={index}
+                    />
+                  ))}
+                </div>
+              </section>
+            );
+          },
+        )}
+
+        {/* About Section */}
+        <section className="w-full bg-white dark:bg-gray-800 rounded-2xl border border-gray-200 dark:border-gray-700 p-6 sm:p-8 mb-8">
+          <h2
+            className={`text-xl sm:text-2xl font-bold text-gray-900 dark:text-white mb-4 ${spaceGrotesk.className}`}
+          >
+            {t("tools.titleCase.aboutTitle")}
+          </h2>
+          <p className="text-gray-600 dark:text-gray-300 mb-6">
+            {t("tools.titleCase.aboutDescription")}
+          </p>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            {/* Writing */}
+            <div className="bg-blue-50 dark:bg-blue-900/20 rounded-xl p-5">
+              <h3 className="font-semibold text-gray-900 dark:text-white mb-3 flex items-center gap-2">
+                <span className="text-lg">✍️</span>
+                {t("tools.titleCase.writingStylesTitle")}
+              </h3>
+              <ul className="space-y-2 text-gray-600 dark:text-gray-300 text-sm">
+                <li>
+                  <strong>AP Style:</strong> {t("tools.titleCase.apDesc")}
+                </li>
+                <li>
+                  <strong>Chicago:</strong> {t("tools.titleCase.chicagoDesc")}
+                </li>
+                <li>
+                  <strong>APA:</strong> {t("tools.titleCase.apaDesc")}
+                </li>
+              </ul>
+            </div>
+
+            {/* Programming */}
+            <div className="bg-emerald-50 dark:bg-emerald-900/20 rounded-xl p-5">
+              <h3 className="font-semibold text-gray-900 dark:text-white mb-3 flex items-center gap-2">
+                <span className="text-lg">💻</span>
+                {t("tools.titleCase.programmingStylesTitle")}
+              </h3>
+              <ul className="space-y-2 text-gray-600 dark:text-gray-300 text-sm">
+                <li>
+                  <strong>camelCase:</strong> {t("tools.titleCase.camelDesc")}
+                </li>
+                <li>
+                  <strong>snake_case:</strong> {t("tools.titleCase.snakeDesc")}
+                </li>
+                <li>
+                  <strong>kebab-case:</strong> {t("tools.titleCase.kebabDesc")}
+                </li>
+              </ul>
+            </div>
+
+            {/* Features */}
+            <div className="bg-purple-50 dark:bg-purple-900/20 rounded-xl p-5">
+              <h3 className="font-semibold text-gray-900 dark:text-white mb-3 flex items-center gap-2">
+                <span className="text-lg">⚡</span>
+                Features
+              </h3>
+              <ul className="space-y-2 text-gray-600 dark:text-gray-300 text-sm">
+                <li>• 16 different case styles</li>
+                <li>• Auto-detects input format</li>
+                <li>• One-click copy any result</li>
+                <li>• 100% private - runs locally</li>
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        {/* CTA Section */}
+        <section className="w-full bg-gradient-to-r from-blue-600 to-purple-600 rounded-2xl p-6 sm:p-8 text-center">
+          <h2 className="text-xl sm:text-2xl font-bold text-white mb-2">
+            {t("tools.bottomCtaTitle")}
+          </h2>
+          <p className="text-blue-100 mb-4">
+            {t("tools.bottomCtaDescription")}
+          </p>
+          <Link
+            href="/"
+            className="inline-block px-6 py-3 bg-white text-blue-600 font-semibold rounded-xl hover:bg-blue-50 transition-colors"
+          >
+            {t("tools.tryGenerator")}
+          </Link>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -185,6 +185,35 @@ Beyond AI generation, Article Idea Generator offers a suite of free writing tool
 
 Browse all available writing tools with descriptions and "coming soon" badges for tools in development.
 
+### Title Case Converter Tool
+
+**URL**: https://articleideagenerator.com/tools/title-case
+
+**Features**:
+- 12 case conversion styles:
+  - Writing styles: Title Case (AP), Title Case (Chicago), APA Style, Sentence case, Start Case, UPPERCASE, lowercase
+  - Programming styles: camelCase, PascalCase, snake_case, kebab-case, CONSTANT_CASE
+- Real-time conversion as you type
+- Auto-detects input case style
+- One-click copy for each style
+- Copy all styles at once
+- Character count display
+- Paste from clipboard button
+
+**Use Cases**:
+- Formatting headlines for articles (AP/Chicago style)
+- Academic paper titles (APA style)
+- Variable naming for code (camelCase, snake_case)
+- CSS class names (kebab-case)
+- Constant definitions (CONSTANT_CASE)
+- URL slugs
+
+**Technical Details**:
+- Client-side processing (no data sent to server)
+- Pure TypeScript conversion functions
+- Mobile-responsive grid layout
+- Accessible with keyboard navigation
+
 ### Planned Tools
 
 - **Character Counter**: Track character limits for Twitter (280), LinkedIn (3000), meta descriptions (160)

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -63,6 +63,19 @@ Free online QR code generator that creates:
 
 Perfect for business cards, restaurant WiFi sharing, product packaging, and event marketing.
 
+### Title Case Converter
+URL: https://articleideagenerator.com/tools/title-case
+
+Free online text case converter that supports:
+- 12 case styles: Title Case (AP/Chicago/APA), Sentence case, UPPERCASE, lowercase, Start Case
+- Programming formats: camelCase, PascalCase, snake_case, kebab-case, CONSTANT_CASE
+- Real-time conversion as you type
+- One-click copy for any style
+- Copy all styles at once
+- Auto-detects current case style
+
+Perfect for writers, developers, journalists, and content creators.
+
 ### Coming Soon
 - Character Counter - Track limits for Twitter, LinkedIn, meta descriptions
 - Reading Time Calculator - Generate "X min read" badges

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -39,6 +39,14 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://www.articleideagenerator.com/tools/title-case</loc>
+    <xhtml:link rel="alternate" hreflang="en" href="https://www.articleideagenerator.com/tools/title-case"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://www.articleideagenerator.com/tools/title-case"/>
+    <lastmod>2026-01-28</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://www.articleideagenerator.com/faq</loc>
     <xhtml:link rel="alternate" hreflang="en" href="https://www.articleideagenerator.com/faq"/>
     <xhtml:link rel="alternate" hreflang="x-default" href="https://www.articleideagenerator.com/faq"/>

--- a/types/tools.ts
+++ b/types/tools.ts
@@ -2,7 +2,13 @@
  * Tool-related types
  */
 
-export type ToolIcon = "document" | "calculator" | "chart" | "clock" | "qrcode";
+export type ToolIcon =
+  | "document"
+  | "calculator"
+  | "chart"
+  | "clock"
+  | "qrcode"
+  | "text";
 
 export interface Tool {
   id: string;


### PR DESCRIPTION
- Add lib/case-converters.ts with 16 conversion functions:
  - Writing styles: AP, Chicago, APA, sentence, start, upper, lower
  - Programming: camelCase, PascalCase, snake_case, kebab-case, CONSTANT, dot, path
  - Special: alternating, inverse
- Add pages/tools/title-case.tsx with animated cards, sample texts, stats
- Add text icon type for tools
- Update translations, sitemap, and LLM docs