### PR TITLE
fix: move devicon stylesheet to _document.tsx

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -19,6 +19,12 @@ export default function Document() {
         <link rel="preconnect" href="https://api.openai.com" />
         <link rel="dns-prefetch" href="https://api.openai.com" />
 
+        {/* Dev Icons for Cover Image Generator */}
+        <link
+          rel="stylesheet"
+          href="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/devicon.min.css"
+        />
+
         <meta
           name="description"
           content="Free AI-powered article title generator that creates SEO-optimized, engaging titles instantly. Beat writer's block and generate creative article ideas in seconds."

--- a/pages/tools/cover-image-generator.tsx
+++ b/pages/tools/cover-image-generator.tsx
@@ -1229,10 +1229,6 @@ export default function CoverImageGeneratorPage(): JSX.Element {
           />
         ))}
         <link rel="alternate" hrefLang="x-default" href={pageUrl} />
-        <link
-          rel="stylesheet"
-          href="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/devicon.min.css"
-        />
 
         <script
           type="application/ld+json"


### PR DESCRIPTION
Fixes Next.js warning about adding stylesheets via next/head

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Developer icon stylesheet relocated to load globally across the application instead of page-specific loading, ensuring availability throughout the entire product.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->