### PR TITLE
fix: replace brittle URL validation regex with URL API

### DIFF
--- a/lib/qr-code-utils.ts
+++ b/lib/qr-code-utils.ts
@@ -469,13 +469,17 @@ export function validateURL(url: string): ValidationResult {
   if (!url) {
     return { isValid: false, error: "URL is required" };
   }
-  // URL validation - supports protocols, paths, query params (UTM), and fragments
-  const urlRegex =
-    /^(https?:\/\/)?([\da-z.-]+)\.([a-z.]{2,6})(:\d+)?(\/[^\s?#]*)?(\?[^\s#]*)?(#[^\s]*)?$/i;
-  if (!urlRegex.test(url)) {
+  // Auto-add https:// if no protocol, then validate with the URL API
+  const urlToTest = /^https?:\/\//i.test(url) ? url : `https://${url}`;
+  try {
+    const parsed = new URL(urlToTest);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return { isValid: false, error: "Invalid URL format" };
+    }
+    return { isValid: true };
+  } catch {
     return { isValid: false, error: "Invalid URL format" };
   }
-  return { isValid: true };
 }
 
 /**


### PR DESCRIPTION
The validateURL regex limited TLDs to 6 characters, rejecting valid URLs with longer TLDs like .technology, .community, .marketing, etc. This caused "Invalid URL format" errors for users entering valid URLs with UTM parameters on domains with longer TLDs.

Replace the regex with the native URL API for robust validation, while preserving support for URLs without a protocol prefix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL validation for QR code generation with automatic `https://` prefixing for incomplete URLs and more robust error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->